### PR TITLE
Add Twitter ETL worker

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,2 +1,37 @@
-# ETL
-Extract Transform Load
+# Twitter ETL Worker
+
+This repository contains a simple worker service that polls tweets from specified accounts, runs text analysis using an LLM, and writes matches to an output file.
+
+## Prerequisites
+
+* .NET 6 SDK
+* Twitter API credentials
+* Access to an OpenAI (or Azure OpenAI) endpoint
+
+## Building
+
+```bash
+# restore packages and build the solution
+ dotnet build TwitterEtl.sln
+```
+
+## Running
+
+Set the following environment variables before running:
+
+* `TWITTER_API_KEY` / `TWITTER_API_SECRET`
+* `TWITTER_ACCESS_TOKEN` / `TWITTER_ACCESS_SECRET`
+* `OPENAI_ENDPOINT` and `OPENAI_KEY`
+* `OPENAI_DEPLOYMENT` – the model deployment name
+
+Then execute the worker:
+
+```bash
+dotnet run --project TwitterEtl.Worker
+```
+
+Tweets that match the prompt criteria will be appended to `results.jsonl` in JSON Lines format.
+
+## Configuration
+
+Modify `Worker.cs` to adjust the list of monitored accounts or change the prompt used when calling the LLM. Prompt templates can be stored in files or environment variables and passed to the worker as needed.

--- a/TwitterEtl.Worker/Program.cs
+++ b/TwitterEtl.Worker/Program.cs
@@ -1,0 +1,11 @@
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.Hosting;
+
+IHost host = Host.CreateDefaultBuilder(args)
+    .ConfigureServices(services =>
+    {
+        services.AddHostedService<Worker>();
+    })
+    .Build();
+
+await host.RunAsync();

--- a/TwitterEtl.Worker/TwitterEtl.Worker.csproj
+++ b/TwitterEtl.Worker/TwitterEtl.Worker.csproj
@@ -1,0 +1,10 @@
+<Project Sdk="Microsoft.NET.Sdk.Worker">
+  <PropertyGroup>
+    <TargetFramework>net6.0</TargetFramework>
+    <Nullable>enable</Nullable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="TweetinviAPI" Version="5.0.4" />
+    <PackageReference Include="Azure.AI.OpenAI" Version="1.0.0-beta.5" />
+  </ItemGroup>
+</Project>

--- a/TwitterEtl.Worker/Worker.cs
+++ b/TwitterEtl.Worker/Worker.cs
@@ -1,0 +1,81 @@
+using System.Text.Json;
+using Microsoft.Extensions.Hosting;
+using Microsoft.Extensions.Logging;
+using Tweetinvi;
+using Tweetinvi.Models;
+using Azure.AI.OpenAI;
+
+public class Worker : BackgroundService
+{
+    private readonly ILogger<Worker> _logger;
+    private readonly TwitterClient _twitterClient;
+    private readonly OpenAIClient _openAiClient;
+    private readonly string[] _accounts = new[] { "@example" };
+
+    public Worker(ILogger<Worker> logger)
+    {
+        _logger = logger;
+        // In real code, keys should come from configuration or secrets
+        _twitterClient = new TwitterClient(
+            Environment.GetEnvironmentVariable("TWITTER_API_KEY"),
+            Environment.GetEnvironmentVariable("TWITTER_API_SECRET"),
+            Environment.GetEnvironmentVariable("TWITTER_ACCESS_TOKEN"),
+            Environment.GetEnvironmentVariable("TWITTER_ACCESS_SECRET"));
+
+        var endpoint = Environment.GetEnvironmentVariable("OPENAI_ENDPOINT");
+        var key = Environment.GetEnvironmentVariable("OPENAI_KEY");
+        if (!string.IsNullOrEmpty(endpoint) && !string.IsNullOrEmpty(key))
+        {
+            _openAiClient = new OpenAIClient(new Uri(endpoint), new Azure.AzureKeyCredential(key));
+        }
+    }
+
+    protected override async Task ExecuteAsync(CancellationToken stoppingToken)
+    {
+        while (!stoppingToken.IsCancellationRequested)
+        {
+            foreach (var account in _accounts)
+            {
+                try
+                {
+                    var user = await _twitterClient.Users.GetUserAsync(account);
+                    var timeline = await _twitterClient.Timelines.GetUserTimelineAsync(user);
+                    foreach (var tweet in timeline)
+                    {
+                        if (await CheckTweetAsync(tweet))
+                        {
+                            await WriteResultAsync(tweet);
+                        }
+                    }
+                }
+                catch (Exception ex)
+                {
+                    _logger.LogError(ex, "Error processing account {Account}", account);
+                }
+            }
+            await Task.Delay(TimeSpan.FromMinutes(5), stoppingToken);
+        }
+    }
+
+    private async Task<bool> CheckTweetAsync(ITweet tweet)
+    {
+        if (_openAiClient == null)
+        {
+            // Fallback simple keyword check
+            return tweet.FullText.Contains("AI", StringComparison.OrdinalIgnoreCase);
+        }
+
+        var prompt = $"Does this tweet mention AI or machine learning? {tweet.FullText}";
+        var response = await _openAiClient.GetCompletionsAsync(
+            Environment.GetEnvironmentVariable("OPENAI_DEPLOYMENT"),
+            prompt);
+        var text = response.Value.Choices[0].Text;
+        return text.Contains("yes", StringComparison.OrdinalIgnoreCase);
+    }
+
+    private static async Task WriteResultAsync(ITweet tweet)
+    {
+        var record = new { tweet.CreatedAt, tweet.FullText, tweet.Author.ScreenName };
+        await File.AppendAllTextAsync("results.jsonl", JsonSerializer.Serialize(record) + "\n");
+    }
+}

--- a/TwitterEtl.sln
+++ b/TwitterEtl.sln
@@ -1,0 +1,18 @@
+Microsoft Visual Studio Solution File, Format Version 12.00
+# Visual Studio Version 17
+VisualStudioVersion = 17.0.31912.275
+MinimumVisualStudioVersion = 10.0.40219.1
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "TwitterEtl.Worker", "TwitterEtl.Worker/TwitterEtl.Worker.csproj", "{01234567-89AB-CDEF-1234-567890ABCDEF}"
+EndProject
+Global
+GlobalSection(SolutionConfigurationPlatforms) = preSolution
+Debug|Any CPU = Debug|Any CPU
+Release|Any CPU = Release|Any CPU
+EndGlobalSection
+GlobalSection(ProjectConfigurationPlatforms) = postSolution
+{01234567-89AB-CDEF-1234-567890ABCDEF}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{01234567-89AB-CDEF-1234-567890ABCDEF}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{01234567-89AB-CDEF-1234-567890ABCDEF}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{01234567-89AB-CDEF-1234-567890ABCDEF}.Release|Any CPU.Build.0 = Release|Any CPU
+EndGlobalSection
+EndGlobal


### PR DESCRIPTION
## Summary
- initialize TwitterEtl solution and worker service
- implement a basic pipeline using Tweetinvi and an OpenAI client
- add NuGet references for Tweetinvi and Azure OpenAI
- document build and run instructions with required environment variables

## Testing
- `dotnet new sln -n TwitterEtl` *(fails: command not found)*
- `dotnet new worker -n TwitterEtl.Worker` *(fails: command not found)*
- `dotnet sln add TwitterEtl.Worker` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_684474ede5b08327b2e30b1c19682203