### PR TITLE
Add ApiClient tests using MSTest

### DIFF
--- a/Twitter.Client.Tests/ApiClientTests.cs
+++ b/Twitter.Client.Tests/ApiClientTests.cs
@@ -1,0 +1,81 @@
+using System;
+using System.Linq;
+using System.Net;
+using System.Net.Http;
+using System.Text;
+using System.Threading;
+using System.Threading.Tasks;
+using Microsoft.VisualStudio.TestTools.UnitTesting;
+using Twitter.Client;
+using Twitter.Client.Models;
+
+namespace Twitter.Client.Tests;
+
+public class FakeHttpMessageHandler : HttpMessageHandler
+{
+    private readonly HttpResponseMessage _response;
+    public HttpRequestMessage? Request { get; private set; }
+
+    public FakeHttpMessageHandler(HttpResponseMessage response)
+    {
+        _response = response;
+    }
+
+    protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+    {
+        Request = request;
+        return Task.FromResult(_response);
+    }
+}
+
+[TestClass]
+public class ApiClientTests
+{
+    [TestMethod]
+    public async Task GetUseIdByNameAsync_ReturnsResponseAndUsesCorrectRequest()
+    {
+        var json = "{\"Id\":\"123\",\"Name\":\"John\",\"Username\":\"john\"}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new FakeHttpMessageHandler(response);
+        var httpClient = new HttpClient(handler);
+        var client = new ApiClient(httpClient);
+
+        var result = await client.GetUseIdByNameAsync(new GetUseIdByNameRequest { Username = "john" });
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual("123", result!.Id);
+        Assert.AreEqual("John", result.Name);
+        Assert.AreEqual("john", result.Username);
+        Assert.IsNotNull(handler.Request);
+        Assert.AreEqual(HttpMethod.Get, handler.Request!.Method);
+        Assert.AreEqual("https://api.twitter.com/2/users/by/username/john", handler.Request.RequestUri!.ToString());
+        Assert.IsTrue(handler.Request.Headers.Accept.Any(h => h.MediaType == "application/json"));
+    }
+
+    [TestMethod]
+    public async Task GetPostsByUserIdAsync_ReturnsItemsAndUsesCorrectRequest()
+    {
+        var json = "{\"Items\":[{\"Id\":\"1\",\"Text\":\"hello\"}]}";
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(json, Encoding.UTF8, "application/json")
+        };
+        var handler = new FakeHttpMessageHandler(response);
+        var httpClient = new HttpClient(handler);
+        var client = new ApiClient(httpClient);
+
+        var result = await client.GetPostsByUserIdAsync(new GetPostsByUserIdRequest { UserId = "42", MaxResults = 5 });
+
+        Assert.IsNotNull(result);
+        Assert.AreEqual(1, result!.Items.Count);
+        Assert.AreEqual("1", result.Items[0].Id);
+        Assert.AreEqual("hello", result.Items[0].Text);
+        Assert.IsNotNull(handler.Request);
+        Assert.AreEqual(HttpMethod.Get, handler.Request!.Method);
+        Assert.AreEqual("https://api.twitter.com/2/users/42/tweets?max_results=5", handler.Request.RequestUri!.ToString());
+        Assert.IsTrue(handler.Request.Headers.Accept.Any(h => h.MediaType == "application/json"));
+    }
+}

--- a/Twitter.Client.Tests/Twitter.Client.Tests.csproj
+++ b/Twitter.Client.Tests/Twitter.Client.Tests.csproj
@@ -1,0 +1,14 @@
+<Project Sdk="Microsoft.NET.Sdk">
+  <PropertyGroup>
+    <TargetFramework>net8.0</TargetFramework>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+  <ItemGroup>
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.7.2" />
+    <PackageReference Include="MSTest.TestAdapter" Version="3.3.2" />
+    <PackageReference Include="MSTest.TestFramework" Version="3.3.2" />
+  </ItemGroup>
+  <ItemGroup>
+    <ProjectReference Include="..\Twitter.Client\Twitter.Client.csproj" />
+  </ItemGroup>
+</Project>

--- a/WalrusEtl.sln
+++ b/WalrusEtl.sln
@@ -6,6 +6,8 @@ Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "WalrusEtl.App", "WalrusEtl.
 EndProject
 Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Twitter.Client", "Twitter.Client/Twitter.Client.csproj", "{C6A842D7-E8D9-4162-97CA-1ECD183F5EE8}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Twitter.Client.Tests", "Twitter.Client.Tests/Twitter.Client.Tests.csproj", "{A880A729-63DD-43EF-946A-66F1469604B8}"
+EndProject
 Global
 GlobalSection(SolutionConfigurationPlatforms) = preSolution
 Debug|Any CPU = Debug|Any CPU
@@ -20,5 +22,9 @@ GlobalSection(ProjectConfigurationPlatforms) = postSolution
 {C6A842D7-E8D9-4162-97CA-1ECD183F5EE8}.Debug|Any CPU.Build.0 = Debug|Any CPU
 {C6A842D7-E8D9-4162-97CA-1ECD183F5EE8}.Release|Any CPU.ActiveCfg = Release|Any CPU
 {C6A842D7-E8D9-4162-97CA-1ECD183F5EE8}.Release|Any CPU.Build.0 = Release|Any CPU
+{A880A729-63DD-43EF-946A-66F1469604B8}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
+{A880A729-63DD-43EF-946A-66F1469604B8}.Debug|Any CPU.Build.0 = Debug|Any CPU
+{A880A729-63DD-43EF-946A-66F1469604B8}.Release|Any CPU.ActiveCfg = Release|Any CPU
+{A880A729-63DD-43EF-946A-66F1469604B8}.Release|Any CPU.Build.0 = Release|Any CPU
 EndGlobalSection
 EndGlobal


### PR DESCRIPTION
## Summary
- create `Twitter.Client.Tests` MSTest project
- add `ApiClient` unit tests
- reference new project in solution

## Testing
- `dotnet test WalrusEtl.sln` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6845768ddf248327be370d7c1eb0bf60